### PR TITLE
Fixed future warning in `comm.py`

### DIFF
--- a/src/bqapi/comm.py
+++ b/src/bqapi/comm.py
@@ -376,7 +376,7 @@ class BQSession:
             auth_service = self.service("auth_service")
             logins = auth_service.login_providers(render="xml")
             login_type = None
-            if logins is not None and logins[0]:
+            if logins is not None and len(logins) > 0:
                 login_type = logins[0].get("type")
             if login_type == "cas":
                 return self.init_cas(


### PR DESCRIPTION
Resolves a future warning when checking credentials tuple passed to initialize a BQSession:

> FutureWarning: Truth-testing of elements was a source of confusion and will always return True in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.